### PR TITLE
Add .NET 9 compilation support

### DIFF
--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>    
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>    
     
     <LangVersion>12</LangVersion>
     <IsPackable>false</IsPackable>

--- a/netDxf/netDxf.csproj
+++ b/netDxf/netDxf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>    
+    <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>    
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageId>netDxf-devel0</PackageId>
 		<PackageVersion>3.2.0</PackageVersion>


### PR DESCRIPTION
This pull request adds support for .NET 9 by updating the TargetFramework in the project files. As part of this update, .NET 5 support has been removed because it was an early, unsupported version. All other existing frameworks remain supported to ensure backward compatibility.